### PR TITLE
bump substreams and prost, prep release 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ opt-level = 's'
 strip = "debuginfo"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Substreams development kit for Antelope chains, contains Firehose Block model and helpers."
 authors = [
@@ -25,6 +25,6 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.76"
 
 [workspace.dependencies]
-substreams-antelope = { version = "0.5.*", path = "./substreams-antelope" }
-substreams-antelope-core = { version = "0.5.*", path = "./core" }
-substreams-antelope-abigen = { version = "0.5.*", path = "./abigen" }
+substreams-antelope = { version = "0.6.*", path = "./substreams-antelope" }
+substreams-antelope-core = { version = "0.6.*", path = "./core" }
+substreams-antelope-abigen = { version = "0.6.*", path = "./abigen" }

--- a/abigen/Cargo.toml
+++ b/abigen/Cargo.toml
@@ -24,4 +24,4 @@ substreams-antelope-core = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"
-substreams = "^0.5.0"
+substreams = "^0.6.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,12 +15,12 @@ readme = "../README.md"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-prost = "0.11"
-prost-types = "0.11"
-substreams = "^0.5.0"
+prost = "0.13"
+prost-types = "0.13"
+substreams = "^0.6.0"
 
 [build-dependencies]
-prost-build = "0.11"
+prost-build = "0.13"
 
 [dev-dependencies]
 anyhow = "1"


### PR DESCRIPTION
see https://github.com/streamingfast/substreams-rs/releases/tag/v0.6.0 for upgrade notes